### PR TITLE
Update 주소가 있을 때 상세페이지에 지도 표시 기능 추가

### DIFF
--- a/src/main/resources/mappers/Boardmapper.xml
+++ b/src/main/resources/mappers/Boardmapper.xml
@@ -42,7 +42,8 @@
 		UPDATE mvc_board6
 		   SET bName = #{bName},
 		   	   bTitle = #{bTitle},
-		   	   bContent = #{bContent}
+		   	   bContent = #{bContent},
+		   	   bAddress = #{bAddress}
 		 WHERE bId = #{bId}
 	</update>
 	

--- a/src/main/webapp/WEB-INF/views/board/detailPage.jsp
+++ b/src/main/webapp/WEB-INF/views/board/detailPage.jsp
@@ -52,7 +52,10 @@
 				<div class="post">
 					${dto.bContent}
 					<!-- 지도 표시 -->
-					<div id="mapContainer" data-bAddress="${dto.bAddress}"></div>
+					<div id="mapContainer">
+						<div id="mapView" data-bAddress="${dto.bAddress}"></div>
+						<div id="addressInfo"></div>
+					</div>
 
 					<div class="post-meta-div">
 						<dl class="post-meta-dl">

--- a/src/main/webapp/WEB-INF/views/board/updatePage.jsp
+++ b/src/main/webapp/WEB-INF/views/board/updatePage.jsp
@@ -5,6 +5,8 @@
 <link href="../../../resources/css/updatePage.css" rel="styleSheet">
 <!-- ckeditor -->
 <script src="${pageContext.request.contextPath}/resources/static/ckeditor/build/ckeditor.js"></script>
+<!-- 주소 검색 -->
+<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 </head>
 <body>
     <%@ include file="/WEB-INF/views/include/loginInfo.jsp" %>
@@ -23,6 +25,11 @@
 			                	* 제목 <input type="text" name="bTitle" value="${dto.bTitle}">
 			                </div>
 			                <textarea rows="10" cols="40" name="bContent" id="editor">${dto.bContent}</textarea>
+			                <!-- map -->
+							<div class="search-box">
+								<input type="text" id="inputAdd" name="bAddress" value="${dto.bAddress}" readonly>
+								<input type="button" onclick="searchedAdd()" value="주소 검색"><br>
+							</div>
 			                <button class="btn btn-outline-info" type="submit" id="updateBtn">완료</button>
 			            </form>
 		            </div>

--- a/src/main/webapp/resources/css/detailPage.css
+++ b/src/main/webapp/resources/css/detailPage.css
@@ -59,6 +59,7 @@ body {
     justify-content: space-between; 
     align-items: center;
     flex-grow: 0; 
+    clear: both;
 }
 
 .post-meta-dl {
@@ -75,6 +76,25 @@ body {
 	font-size: 13px;
 	margin: 0px;
 }
+
+#mapContainer {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 40px;  
+}
+
+#mapContainer #mapView {
+	width: 100%;
+  	height: 300px;
+  	display: block;
+}
+
+#mapContainer #addressInfo {
+	font-size: 14px;
+  	color: #333;
+  	text-align: right;
+}
+
 
 /* 각 dt 항목 뒤에 · 추가 */
 .post-meta-dl .post-meta-item:not(:first-child)::before {

--- a/src/main/webapp/resources/css/detailPage.css
+++ b/src/main/webapp/resources/css/detailPage.css
@@ -78,15 +78,15 @@ body {
 }
 
 #mapContainer {
-	display: flex;
+	display: none;
 	flex-direction: column;
 	margin-bottom: 40px;  
 }
 
 #mapContainer #mapView {
+  	display: none;
 	width: 100%;
   	height: 300px;
-  	display: block;
 }
 
 #mapContainer #addressInfo {

--- a/src/main/webapp/resources/js/detailPage.js
+++ b/src/main/webapp/resources/js/detailPage.js
@@ -190,8 +190,8 @@ const address = mapView.getAttribute("data-bAddress")
 const addressInfo = mapContainer.querySelector("#addressInfo")
 
 if(address) {
-	mapContainer.style.display = "block"
-	mapContainer.style.height = '300px'
+	mapContainer.style.display = "flex"
+	mapView.style.display = "block"
 	// 저장된 지도가 있다면
 	const mapOption = { // 지도 생성 시 필요한 기본 옵션
 		center: new daum.maps.LatLng(33.450701, 126.570667), // 지도의 중심좌표
@@ -206,7 +206,6 @@ if(address) {
 		position: new daum.maps.LatLng(37.537187, 127.005476),
 		map: map
 	})
-
 	
 	// 주소로 상세 정보를 검색
 	geocoder.addressSearch(address, function(results, status) {
@@ -222,10 +221,7 @@ if(address) {
 		}
 	})
 	addressInfo.innerHTML = `<div>${address}</div>`
-} else {
-	mapContainer.style.display = 'none'
-	// addressText.style.display = 'none'
-}
+} 
 
 /* 페이지 로드 시 실행될 함수
 ================================================== */

--- a/src/main/webapp/resources/js/detailPage.js
+++ b/src/main/webapp/resources/js/detailPage.js
@@ -184,18 +184,21 @@ chatButton.addEventListener('click', () => {
 /* 작성자가 등록한 지도가 있다면 표시
 ================================================== */
 
-const mapContainer = document.querySelector('#mapContainer')
-const address = mapContainer.getAttribute("data-bAddress")
+const mapContainer = document.querySelector("#mapContainer")
+const mapView = mapContainer.querySelector("#mapView")
+const address = mapView.getAttribute("data-bAddress")
+const addressInfo = mapContainer.querySelector("#addressInfo")
 
 if(address) {
-	mapContainer.style.height = '400px'
+	mapContainer.style.display = "block"
+	mapContainer.style.height = '300px'
 	// 저장된 지도가 있다면
 	const mapOption = { // 지도 생성 시 필요한 기본 옵션
 		center: new daum.maps.LatLng(33.450701, 126.570667), // 지도의 중심좌표
 		level: 5 // 지도의 확대, 축소 레벨
 	}
 	// 지도를 미리 생성
-	const map = new daum.maps.Map(mapContainer, mapOption)
+	const map = new daum.maps.Map(mapView, mapOption)
 	// 주소-좌표 변환 객체를 생성
 	const geocoder = new daum.maps.services.Geocoder()
 	// 마커를 미리 생성
@@ -204,27 +207,24 @@ if(address) {
 		map: map
 	})
 
-	new daum.Postcode({
-        oncomplete: function(data) {
-    		// 검색한 주소 값을 <input>에 설정
-            // const addr = data.address // 최종 주소 변수
-            // document.querySelector('#inputAdd').value = addr
-            
-            // 주소로 상세 정보를 검색
-            geocoder.addressSearch(data.address, function(results, status) {
-                if (status === daum.maps.services.Status.OK) {
-                    const result = results[0] // 첫번째 결과의 값을 활용
-                    const coords = new daum.maps.LatLng(result.y, result.x); // 해당 주소 좌표 받기
-                    mapContainer.style.display = "block"
-                    map.relayout()
-                    map.setCenter(coords) // 지도 중심 변경
-                    marker.setPosition(coords) // 마커를 주소 위치로 변경
-                }
-            })
-        }
-    }).open()
+	
+	// 주소로 상세 정보를 검색
+	geocoder.addressSearch(address, function(results, status) {
+		if (status === daum.maps.services.Status.OK) {
+			const result = results[0]
+			const coords = new daum.maps.LatLng(result.y, result.x); // 해당 주소 좌표 받기
+			
+			setTimeout(() => {
+				map.relayout()
+				map.setCenter(coords)
+				marker.setPosition(coords) // 마커를 주소 위치로 변경
+			}, 100)
+		}
+	})
+	addressInfo.innerHTML = `<div>${address}</div>`
 } else {
 	mapContainer.style.display = 'none'
+	// addressText.style.display = 'none'
 }
 
 /* 페이지 로드 시 실행될 함수

--- a/src/main/webapp/resources/js/updatePage.js
+++ b/src/main/webapp/resources/js/updatePage.js
@@ -18,3 +18,13 @@ function MyCustomUploadAdapterPlugin(editor) {
       return new UploadAdapter(loader)
   }
 }
+
+// 검색한 주소를 [input]에 set
+const searchedAdd = () => {
+    new daum.Postcode({
+        oncomplete: function(data) {
+          const addr = data.address // 최종 주소 변수
+          document.querySelector('#inputAdd').value = addr
+        }
+    }).open()
+}

--- a/target/classes/mappers/Boardmapper.xml
+++ b/target/classes/mappers/Boardmapper.xml
@@ -42,7 +42,8 @@
 		UPDATE mvc_board6
 		   SET bName = #{bName},
 		   	   bTitle = #{bTitle},
-		   	   bContent = #{bContent}
+		   	   bContent = #{bContent},
+		   	   bAddress = #{bAddress}
 		 WHERE bId = #{bId}
 	</update>
 	


### PR DESCRIPTION
## 📌 변경 사항
- BoardMapper.xml: 작성된 글의 주소 수정 시 업데이트되도록 UPDATE 구문에 주소 컬럼 추가
- detailPage.jsp: 지도 영역과 주소 영역을 구분시키고 한 개의 div로 묶음
- updatePage.jsp: 작성된 글을 수정할 때 주소를 재지정 또는 추가할 수 있도록 수정
- detailPage.css: 지도 표시 영역 스타일 지정
- detailPage.js
  - 상세페이지 진입 시 우편 주소 검색창이 자동으로 열리는 부분 삭제  
  - 지도가 렌더링 될 때 post 단이 겹치지 않도록 setTimeout으로 0.1초 지연 처리 추가  
  - 지도가 없을 경우 지도 영역 숨김 처리 개선

## 🛠️ 수정한 이유
- 상세페이지에서 글 작성자가 등록한 주소가 있을 때 지도와 주소가 제대로 표시되어야 하기 때문
- 주소 검색 UI가 상세페이지에서 불필요하게 자동 실행되는 문제 해결
- 지도와 주소 정보가 레이아웃에서 겹치는 문제 방지

## 🔍 주요 변경 파일
- BoardMapper.xml
- detailPage.jsp
- updatePage.jsp
- detailPage.css
- detailPage.js

## ✅ 테스트 확인 내용
- [x] 지도와 주소가 상세페이지에 정상 표시되는지 확인
- [x] 상세페이지 접속 시 주소 검색창이 자동으로 열리지 않는지 확인
- [x] 글 수정 페이지에서 주소 수정 및 추가가 정상 동작하는지 확인
- [x] 기존 기능들에 영향 없는지 확인

## 🔗 관련 이슈
closes #1