### PR TITLE
[BUG] 이메일 인코딩 오류 및 인증번호 박스 정렬 문제 수정

### DIFF
--- a/src/main/java/com/my/ex/controller/MailController.java
+++ b/src/main/java/com/my/ex/controller/MailController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.my.ex.service.MailSendService;
 
-//@Controller
 @RestController
 @RequestMapping("/userMail")
 public class MailController {
@@ -23,16 +22,14 @@ public class MailController {
 	private MailSendService mailService;
 	private String authNum = "";
 	
-//	@ResponseBody
-	@RequestMapping(value= "/send", method = RequestMethod.GET, produces = "application/text;charset=utf8")
+	@RequestMapping(value= "/send", method = RequestMethod.GET, produces = "application/text;charset=utf-8")
 	public ResponseEntity<String> sendMail(@RequestParam("uemail")String uemail){
 		HashMap<String, String> map = mailService.joinEmail(uemail);
 		authNum = map.get("authNum");
 		return ResponseEntity.ok(map.get("message"));
 	}
 	
-//	@ResponseBody
-	@RequestMapping(value= "/check", method = RequestMethod.POST, produces = "application/text;charset=utf8")
+	@RequestMapping(value= "/check", method = RequestMethod.POST, produces = "application/text;charset=utf-8")
 	public ResponseEntity<String> emailCheck(@RequestParam("userCode")String userCode){
 		String result = (userCode.equals(authNum)) ? "인증성공" : "인증실패";
 		return new ResponseEntity<String>(result, HttpStatus.OK);

--- a/src/main/java/com/my/ex/service/MailSendService.java
+++ b/src/main/java/com/my/ex/service/MailSendService.java
@@ -5,6 +5,7 @@ import java.util.Random;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeUtility;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,9 +39,9 @@ public class MailSendService {
 		String toMail = uemail;
 		String title = "[HomeTalk] 본인 확인을 위한 인증 코드입니다.";
 		String boxStyle = "width:250px; height:60px; border:1.5px solid Tomato; border-radius:8px; " +
-                		  "display:flex; justify-content:center; " +
-                		  "align-items:center; font-size:20px; font-weight:500; color:Tomato;";
-		String content = "<h2>요청하신 인증을 위해 아래의 인증 코드를 입력해 주세요.</h2><br>" +
+						  "text-align:center; vertical-align: middle; line-height: 60px;" +
+						  "font-size:20px; font-weight:500; color:Tomato;";
+		String content = "<meta charset=\"UTF-8\"><h2>요청하신 인증을 위해 아래의 인증 코드를 입력해 주세요.</h2><br>" +
                 		 "<p>이 인증 코드는 회원가입 또는 아이디/비밀번호 찾기를 위해 발송되었습니다.</p>" +
                 		 "<p>아래의 인증코드를 입력하시면 다음 단계로 진행됩니다.</p>" +
 						 "<div style=\"" + boxStyle + "\">" + authNum + "</div>" +


### PR DESCRIPTION
## 📌 변경 사항
- 컨트롤러 응답 ```Content-Type charset```을 ```utf8```에서 ```utf-8```로 수정
- 이메일 HTML 본문에 ```<meta charset="UTF-8">``` 태그 추가
- 인증번호 박스 CSS에서 ```display: flex``` 제거, ```line-height``` 및 테이블 레이아웃으로 변경

## 🛠️ 수정한 이유
- 일부 이메일 클라이언트에서 한글 인코딩이 깨지는 문제 해결
- 인증번호 박스 정렬 오류를 개선하여 다양한 클라이언트 호환성 확보

## 🔍 주요 변경 파일
- MainController.java
- MainSenderService.java

## ✅ 테스트 내용
- [x] 이메일 발송 시 한글 인코딩이 Google, Naver, Nate 메일 클라이언트에서 정상 확인됨
- [x] 인증번호 박스가 Google, Naver, Nate 메일 클라이언트에서 가운데 정렬로 표시됨
- [x] 기존 기능 정상 작동 및 UI 오류 없음 확인

## 🔗 관련 이슈
closes #40 