### PR TITLE
[ENH] 현재 프로젝트 내에서 사용되는 이미지 URL, WebSocket URL 등의 정적 경로 설정 방식 v1

### DIFF
--- a/src/main/java/com/my/ex/controller/UserController.java
+++ b/src/main/java/com/my/ex/controller/UserController.java
@@ -81,7 +81,7 @@ public class UserController {
 	@RequestMapping("/logout")
 	public String logout(HttpSession session) {
 		session.invalidate(); // 세션 자체를 삭제
-		return "redirect:loginPage";
+		return "redirect:/board/paging";
 	}
 	
 	// 회원가입 페이지

--- a/src/main/java/com/my/ex/dto/google/GoogleLoginRequestDto.java
+++ b/src/main/java/com/my/ex/dto/google/GoogleLoginRequestDto.java
@@ -1,6 +1,9 @@
 package com.my.ex.dto.google;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+
+import com.my.ex.EnvironmentService;
 
 import lombok.Builder;
 
@@ -33,11 +36,15 @@ public class GoogleLoginRequestDto {
 	
 	@Value("${google.oauthBaseUri}")
 	private String oauthBaseUri;
+	
+	@Value("${google.redirect_prod_uri}")
+	private String redirect_prod_uri;
 
 	public GoogleLoginRequestDto() {}
 
 	public GoogleLoginRequestDto(String baseurl, String response_type, String client_id, String client_secret,
-			String state, String redirect_uri, String scope, String access_type, String oauthBaseUri) {
+			String state, String redirect_uri, String scope, String access_type, String oauthBaseUri,
+			String redirect_prod_uri) {
 		this.baseurl = baseurl;
 		this.response_type = response_type;
 		this.client_id = client_id;
@@ -47,6 +54,7 @@ public class GoogleLoginRequestDto {
 		this.scope = scope;
 		this.access_type = access_type;
 		this.oauthBaseUri = oauthBaseUri;
+		this.redirect_prod_uri = redirect_prod_uri;
 	}
 
 	public String getBaseurl() {
@@ -121,11 +129,20 @@ public class GoogleLoginRequestDto {
 		this.oauthBaseUri = oauthBaseUri;
 	}
 
+	public String getRedirect_prod_uri() {
+		return redirect_prod_uri;
+	}
+
+	public void setRedirect_prod_uri(String redirect_prod_uri) {
+		this.redirect_prod_uri = redirect_prod_uri;
+	}
+
 	@Override
 	public String toString() {
 		return "GoogleLoginRequestDto [baseurl=" + baseurl + ", response_type=" + response_type + ", client_id="
 				+ client_id + ", client_secret=" + client_secret + ", state=" + state + ", redirect_uri=" + redirect_uri
-				+ ", scope=" + scope + ", access_type=" + access_type + ", oauthBaseUri=" + oauthBaseUri + "]";
+				+ ", scope=" + scope + ", access_type=" + access_type + ", oauthBaseUri=" + oauthBaseUri
+				+ ", redirect_prod_uri=" + redirect_prod_uri + "]";
 	}
-
+	
 }

--- a/src/main/java/com/my/ex/dto/naver/NaverLoginRequestDto.java
+++ b/src/main/java/com/my/ex/dto/naver/NaverLoginRequestDto.java
@@ -21,17 +21,21 @@ public class NaverLoginRequestDto {
 
 	@Value("${naver.redirect_uri}")
 	private String redirect_uri;
+	
+	@Value("${naver.redirect_prod_uri}")
+	private String redirect_prod_uri;
 
 	public NaverLoginRequestDto() {}
 
-	public NaverLoginRequestDto(String baseurl, String response_type, String client_id, String client_secret, String state,
-			String redirect_uri) {
+	public NaverLoginRequestDto(String baseurl, String response_type, String client_id, String client_secret,
+			String state, String redirect_uri, String redirect_prod_uri) {
 		this.baseurl = baseurl;
 		this.response_type = response_type;
 		this.client_id = client_id;
 		this.client_secret = client_secret;
 		this.state = state;
 		this.redirect_uri = redirect_uri;
+		this.redirect_prod_uri = redirect_prod_uri;
 	}
 
 	public String getBaseurl() {
@@ -82,10 +86,19 @@ public class NaverLoginRequestDto {
 		this.redirect_uri = redirect_uri;
 	}
 
+	public String getRedirect_prod_uri() {
+		return redirect_prod_uri;
+	}
+
+	public void setRedirect_prod_uri(String redirect_prod_uri) {
+		this.redirect_prod_uri = redirect_prod_uri;
+	}
+
 	@Override
 	public String toString() {
-		return "SocialDto [baseurl=" + baseurl + ", response_type=" + response_type + ", client_id=" + client_id
-				+ ", client_secret=" + client_secret + ", state=" + state + ", redirect_uri=" + redirect_uri + "]";
+		return "NaverLoginRequestDto [baseurl=" + baseurl + ", response_type=" + response_type + ", client_id="
+				+ client_id + ", client_secret=" + client_secret + ", state=" + state + ", redirect_uri=" + redirect_uri
+				+ ", redirect_prod_uri=" + redirect_prod_uri + "]";
 	}
 
 }

--- a/src/main/java/com/my/ex/service/SocialService.java
+++ b/src/main/java/com/my/ex/service/SocialService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import com.my.ex.EnvironmentService;
 import com.my.ex.dto.SocialDto;
 import com.my.ex.dto.google.GoogleCallbackDto;
 import com.my.ex.dto.google.GoogleLoginRequestDto;
@@ -33,6 +34,25 @@ public class SocialService implements ISocialService {
 	@Autowired
 	private GoogleLoginRequestDto googleLoginRequestDto;
 	
+	@Autowired
+	private EnvironmentService environmentService;
+	
+	// google redirect_uri
+	public String getGoogleRedirectURI() {
+		if(environmentService.getActiveProfile().equals("prod")) {
+			return googleLoginRequestDto.getRedirect_prod_uri();
+		}
+		return googleLoginRequestDto.getRedirect_uri();
+	}
+	
+	// naver redirect_uri
+	public String getNaverRedirectURI() {
+		if(environmentService.getActiveProfile().equals("prod")) {
+			return naverLoginRequestDto.getRedirect_prod_uri();
+		}
+		return naverLoginRequestDto.getRedirect_uri();
+	}
+	
 	// 네이버 로그인 연동 URL 생성
 	@Override
 	public String getNaverAuthorizeUrl(String type) throws URISyntaxException, MalformedURLException, UnsupportedEncodingException {
@@ -41,7 +61,8 @@ public class SocialService implements ISocialService {
 				.queryParam("response_type", naverLoginRequestDto.getResponse_type())
 				.queryParam("client_id", naverLoginRequestDto.getClient_id())
 				.queryParam("state", URLEncoder.encode(naverLoginRequestDto.getState(), "UTF-8"))
-				.queryParam("redirect_uri", URLEncoder.encode(naverLoginRequestDto.getRedirect_uri(), "UTF-8"))
+//				.queryParam("redirect_uri", URLEncoder.encode(naverLoginRequestDto.getRedirect_uri(), "UTF-8"))
+				.queryParam("redirect_uri", URLEncoder.encode(getNaverRedirectURI(), "UTF-8"))
 				.build();
 		return uriComponents.toString();
 	}
@@ -95,7 +116,8 @@ public class SocialService implements ISocialService {
 				.queryParam("scope", googleLoginRequestDto.getScope()) // 구글 api에서 선택한 범위
 				.queryParam("state", URLEncoder.encode(googleLoginRequestDto.getState(), "UTF-8"))
 				.queryParam("access_type", googleLoginRequestDto.getAccess_type())
-				.queryParam("redirect_uri", URLEncoder.encode(googleLoginRequestDto.getRedirect_uri(), "UTF-8"))
+//				.queryParam("redirect_uri", URLEncoder.encode(googleLoginRequestDto.getRedirect_uri(), "UTF-8"))
+				.queryParam("redirect_uri", URLEncoder.encode(getGoogleRedirectURI(), "UTF-8"))
 				.build();
 		return uriComponents.toString();
 	}
@@ -112,7 +134,8 @@ public class SocialService implements ISocialService {
 				.queryParam("client_secret", googleLoginRequestDto.getClient_secret())
 				.queryParam("code", googleCallbackDto.getCallbackCode())
 				.queryParam("state", googleCallbackDto.getCallbackState())
-				.queryParam("redirect_uri", URLEncoder.encode(googleLoginRequestDto.getRedirect_uri(), "UTF-8"))
+//				.queryParam("redirect_uri", URLEncoder.encode(googleLoginRequestDto.getRedirect_uri(), "UTF-8"))
+				.queryParam("redirect_uri", URLEncoder.encode(getGoogleRedirectURI(), "UTF-8"))
 				.build();
 		
 		// POST 요청에 필요한 본문 데이터 구성


### PR DESCRIPTION
## 📌 변경 사항
- 이미지 업로드/조회, ```WebSocket```, ```OAuth redirect URI``` 등 외부 API 관련 URL을 ```.properties``` 설정을 기반으로 동적으로 분기되도록 변경
- ```EnvironmentService``` 클래스를 통해 ```spring.profiles.active``` 값이 ```dev```, ```prod```인지에 따라 URL 반환
- 네이버/구글 OAuth 로그인 시 ```redirect URI```가 환경에 따라 다르게 설정되도록 수정
- 카카오맵 사용 시 Web 플랫폼 설정에서 개발/운영 환경의 도메인 추가 (코드 수정 없이 사이트 등록만 진행)

## 🛠️ 수정한 이유
- 기존에는 URL이 코드 내에 하드코딩되어 있어, 개발/운영 환경 전환 시 수동 변경이 필요했음
- 설정 파일 기반 분기로 유지보수성과 배포 효율성을 높이기 위함
- API 키 또는 URL 변경 시 ```application.properties```에서만 조정 가능하도록 개선

## 🔍 주요 변경 파일
- ```EnvironmentService.java```: 환경별 URL 제공 로직 추가
- ```SocialController.java```: OAuth redirect URI 설정 방식 수정
- ```application.properties```: dev/prod 환경에 따른 URL 속성 추가
- ```naverLoginRequestDto```
- ```googleLoginRequestDto```

## ✅ 테스트 내용
- [x] 네이버 로그인 (dev/prod 환경 각각에서 redirect URI 정상 동작 확인)
- [x] 구글 로그인 (dev/prod 환경 각각에서 redirect URI 정상 동작 확인)
- [x] 이미지 업로드/조회 경로 정상 작동
- [x] WebSocket 연결 정상 작동
- [x] 기존 기능 영향 없음 확인

## 🔗 관련 이슈
closes #53 
