### PR TITLE
[FEAT] 사용자 알림 기능 구현

### DIFF
--- a/src/main/java/com/my/ex/controller/BoardController.java
+++ b/src/main/java/com/my/ex/controller/BoardController.java
@@ -47,11 +47,13 @@ import com.my.ex.dto.BoardPagingDto;
 import com.my.ex.dto.BookmarkDto;
 import com.my.ex.dto.CommentsPagingDto;
 import com.my.ex.dto.LikeDto;
+import com.my.ex.dto.NotificationDto;
 import com.my.ex.dto.TagDto;
 import com.my.ex.dto.map.KakaoMapRequestDto;
 import com.my.ex.service.BoardService;
 import com.my.ex.service.BookmarkService;
 import com.my.ex.service.LikeService;
+import com.my.ex.service.NotificationService;
 import com.my.ex.service.SocialService;
 import com.my.ex.service.UserService;
 
@@ -145,31 +147,48 @@ public class BoardController {
 	
 	// 게시글 상세보기
 	@RequestMapping("/detailBoard")
-	public String detailBoard(@RequestParam(value = "page", required = false, defaultValue = "1") int page,
-		@RequestParam(value = "sortType", required = false, defaultValue = "latest") String sortType,
-		HttpServletRequest request,
-		Model model, 
-		HttpSession session, 
-		@RequestParam int bId, 
-		@RequestParam int bGroup,
-		@RequestParam String bName) {
+	public String detailBoard(
+			@RequestParam(value = "page", required = false, defaultValue = "1") int page,
+			@RequestParam(value = "sortType", required = false, defaultValue = "latest") String sortType,
+			@RequestParam(value = "commentPage", required = false, defaultValue = "1") int commentPage,
+			@RequestParam(value = "targetCommentId", required = false) Integer targetCommentId, // 알림을 통해 직접 넘어온 댓글 ID
+			HttpServletRequest request,
+			Model model, 
+			HttpSession session, 
+			@RequestParam int bId, 
+			@RequestParam int bGroup,
+			@RequestParam String bName) {
 		
 		String userId = (String)session.getAttribute("userId"); 
 		
 		// 게시글 조회
 		BoardDto dto = service.detailBoard(bId);
+		
 		// 해당 게시글에 사용자가 좋아요를 눌렀는지 확인
 		boolean isLiked = likeService.isLiked(bId, userId);
+		
 		// 해당 게시글에 사용자가 북마크를 눌렀는지 확인
 		boolean isBookmarked = bookmarkService.isBookmarked(bId, userId);
+		
+		// 만약 알림 링크를 통해 targetCommentId가 넘어왔다면, 해당 댓글의 실제 페이지를 계산
+		int actualCommentPageToLoad = 1; // 기본적으로 1페이지 로드
+		if(targetCommentId != null) {
+			int commentsPageLimit = 6; // 서비스와 동일한 값 사용
+			// 해당 targetCommentId가 현재 몇번째 페이지에 위치하는지 계산
+			actualCommentPageToLoad = service.calculateCommentPage(targetCommentId, bGroup, commentsPageLimit);
+		} 
+		
 		// 댓글 페이징 정보
-		commentsPaging(page, sortType, bGroup, model, userId);
+//		commentsPaging(commentPage, sortType, bGroup, model, userId);
+		commentsPaging(actualCommentPageToLoad, sortType, bGroup, model, userId);
+		
 		// 좋아요 수 업데이트
 		updateHitCount(bId);
+		
 		// 프로필 이미지 url 반환
 		String filename = userService.getProfileFilename(bName);
-				
 		String imageUrl = "/user/getProfileImage/" + filename;
+		
 		// 태그 저장
 		List<TagDto> tagList = service.findTagsByPostId(bId);
 		
@@ -243,14 +262,35 @@ public class BoardController {
 	// 게시글 좋아요
 	@ResponseBody
 	@RequestMapping(value =  "/addLike", method = RequestMethod.POST)
-	public ResponseEntity<Integer> addLike(@RequestParam("bId")int bId, HttpSession session) {
+	public ResponseEntity<Integer> addLike(@RequestParam("bId")int bId,
+			@RequestParam String bName,
+			@RequestParam int bGroup,
+			HttpSession session) {
 		String userId = (String)session.getAttribute("userId");
+		
+		// 게시글 좋아요 개수 늘림
 		service.incrementLikesCount(bId);
+		
+		// 좋아요 테이블에 추가
 		LikeDto dto = new LikeDto();
 		dto.setBId(bId);
 		dto.setUserId(userId);
-		likeService.addLike(dto);
+		
+		// 알림 정보 넘김
+		NotificationDto notificationDto = new NotificationDto();
+		notificationDto.setUserId(bName); // 알림을 받을 사용자ID
+		notificationDto.setType("LIKE");
+		notificationDto.setRelatedId(bId);
+		notificationDto.setSenderId(userId); // 알림을 발생시킨 사용자ID
+		notificationDto.setLink("/board/detailBoard?"
+				+ "bId=" + bId
+				+ "&bGroup=" + bGroup 
+				+ "&bName=" + bName);
+		likeService.addLike(dto, notificationDto);
+		
+		// 게시글 좋아요 총 개수 조회
 		int totalLikes = service.getTotalLikes(bId);
+		
 		return new ResponseEntity<>(totalLikes, HttpStatus.OK);
 	}
 	
@@ -342,10 +382,18 @@ public class BoardController {
 	public Map<String, Object> replyInsert(@RequestParam(value = "page", required = false, defaultValue = "1") int page,
 										   @RequestParam(value = "sortType", required = false, defaultValue = "latest") String sortType,
 										   HttpSession session,
-										   BoardDto dto) {
+										   BoardDto dto,
+										   @RequestParam String boardWriterId) {
 		String userId = (String)session.getAttribute("userId");
-		dto.setbName(userId);
-		service.replyInsert(dto);
+		dto.setbName(userId); // 댓글 작성자ID (알림을 발생시킨 사용자ID)
+		
+		// 알림 정보 넘김
+		NotificationDto notificationDto = new NotificationDto();
+		notificationDto.setUserId(boardWriterId); // 알림을 받을 사용자ID
+		notificationDto.setType("COMMENT");
+		notificationDto.setSenderId(userId); // 알림을 발생시킨 사용자ID
+		
+		service.replyInsert(dto, notificationDto, page);
 		
 		int commentsCount = service.incrementCommentCount(dto.getbGroup());
 		CommentsListResponse response = commentsPagingAjax(page, sortType, dto.getbGroup(), session);
@@ -516,9 +564,9 @@ public class BoardController {
 	}
 	
 	// 댓글 페이징_로드
-	public Model commentsPaging(int page, String sortType, int bGroup, Model model, String userId) {
+	public Model commentsPaging(int commentPage, String sortType, int bGroup, Model model, String userId) {
 		// 댓글 목록
-		List<BoardDto> commentsPagingList = service.commentsPagingList(page, sortType, bGroup);
+		List<BoardDto> commentsPagingList = service.commentsPagingList(commentPage, sortType, bGroup);
 		
 		// 프로필 이미지 목록
 		List<String> profileImageUrls = new ArrayList<>();
@@ -528,7 +576,7 @@ public class BoardController {
 			profileImageUrls.add(imageUrl);
 		}
 		
-		CommentsPagingDto commentsPageDto = service.commentsPagingParam(page, bGroup);
+		CommentsPagingDto commentsPageDto = service.commentsPagingParam(commentPage, bGroup);
 		for(BoardDto dto : commentsPagingList) {
 			dto.setSortType(sortType);
 			// HTML 이스케이프 처리
@@ -547,12 +595,13 @@ public class BoardController {
 	// 댓글 페이징_비동기
 	@ResponseBody
 	@RequestMapping("/commentsPaging/ajax")
-	public CommentsListResponse commentsPagingAjax(@RequestParam(value = "page", required = false, defaultValue = "1") int page,
-												   @RequestParam(value = "sortType", required = false, defaultValue = "latest") String sortType,
-												   int bGroup,
-												   HttpSession session) {
+	public CommentsListResponse commentsPagingAjax(
+			@RequestParam(value = "page", required = false, defaultValue = "1") int currentcommentPage,
+			@RequestParam(value = "sortType", required = false, defaultValue = "latest") String sortType,
+			int bGroup,
+			HttpSession session) {
 		// 'page', 'sortType' 값이 없는 경우 지정해주어야하는데, fetch로 보내면 @RequestParam을 사용못하기때문에 $.ajax로 요청하고 @RequestParam을 사용 
-		List<BoardDto> commentsPagingList = service.commentsPagingList(page, sortType, bGroup);
+		List<BoardDto> commentsPagingList = service.commentsPagingList(currentcommentPage, sortType, bGroup);
 		
 		// 프로필 이미지 목록
 		List<String> profileImageUrls = new ArrayList<>();
@@ -562,7 +611,7 @@ public class BoardController {
 			profileImageUrls.add(imageUrl);
 		}
 		
-		CommentsPagingDto commentsPageDto = service.commentsPagingParam(page, bGroup);
+		CommentsPagingDto commentsPageDto = service.commentsPagingParam(currentcommentPage, bGroup);
 		String userId = UserController.getUserIdFromSession(session);
 		for(BoardDto dto : commentsPagingList) {
 			dto.setSortType(sortType);

--- a/src/main/java/com/my/ex/controller/NotificationController.java
+++ b/src/main/java/com/my/ex/controller/NotificationController.java
@@ -1,0 +1,100 @@
+package com.my.ex.controller;
+
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.my.ex.dto.NotificationDto;
+import com.my.ex.dto.NotificationResponseDto;
+import com.my.ex.service.NotificationService;
+
+@Controller
+@RequestMapping("/notification")
+public class NotificationController {
+	
+	@Autowired
+	private NotificationService service;
+	
+	// 알림 아이콘 눌렀을 때 조회(최근 3일 내역만)
+	@GetMapping("/getNotifications")
+	@ResponseBody
+	public NotificationResponseDto getNotification(HttpSession session) {
+		String userId = (String) session.getAttribute("userId");
+		
+		List<NotificationDto> notificationList = service.getNotifications(userId);
+		int unreadCount = service.getUnreadCount(userId);
+		
+		NotificationResponseDto responseDto = new NotificationResponseDto();
+		responseDto.setNotificationDtos(notificationList);
+		responseDto.setUnreadCount(unreadCount);
+		
+		return responseDto;
+	}
+	
+	// 모든 알림 보기 눌렀을 때(모든 알림 조회)
+	@GetMapping("/getAllNotifications")
+	public String getAllNotifications(
+			HttpSession session, 
+			Model model,
+			@RequestParam(defaultValue = "1") int page,
+			@RequestParam(defaultValue = "10") int size) throws JsonProcessingException {
+		
+		String userId = (String) session.getAttribute("userId");
+		int offset = (page - 1) * size; // 몇 번째부터 가져올지(인덱스 기준)
+		
+		List<NotificationDto> notificationAllList = service.getAllNotifications(userId, size, offset);
+		
+		// 응답 데이터를 js에서 사용할 수 있도록 List -> JSON 변환
+		// JSON 변환 없이는 js에서 forEach() 사용 안됨
+		ObjectMapper mapper = new ObjectMapper();
+		String jsonList = mapper.writeValueAsString(notificationAllList);
+		
+		model.addAttribute("notificationAllListJson", jsonList);
+		
+		return "/user/getNotifications";
+	}
+	
+	// 모든 알림 보기 눌렀을 때(모든 알림 조회) - 옵저버
+	@GetMapping("/getAllNotifications/axios")
+	@ResponseBody
+	public List<NotificationDto> getAllNotificationsAxios(
+			HttpSession session, 
+			@RequestParam(defaultValue = "1") int page,
+			@RequestParam(defaultValue = "10") int size) throws JsonProcessingException {
+		
+		String userId = (String) session.getAttribute("userId");
+		int offset = (page - 1) * size; // 몇 번째부터 가져올지(인덱스 기준)
+		
+		return service.getAllNotifications(userId, size, offset);
+	}
+	
+	// 읽음 상태 업데이트
+	@PatchMapping("/updateReadStatus")
+	@ResponseBody
+	public NotificationResponseDto updateReadStatus(@RequestBody NotificationDto dto, HttpSession session) {
+		String userId = (String) session.getAttribute("userId");
+		
+		boolean isUpdated = service.updateReadStatus(dto.getNotificationId());
+		int unreadCount = service.getUnreadCount(userId);
+		
+		NotificationResponseDto responseDto = new NotificationResponseDto();
+		responseDto.setReadStatusUpdated(isUpdated);
+		responseDto.setUnreadCount(unreadCount);
+		
+		return responseDto;
+	}
+	
+}

--- a/src/main/java/com/my/ex/dao/BoardDao.java
+++ b/src/main/java/com/my/ex/dao/BoardDao.java
@@ -220,4 +220,9 @@ public class BoardDao implements IBoardDao {
 		return session.selectList(NAMESPACE + "getAllTags");
 	}
 
+	@Override
+	public int getCommentOrderById(Map<String, Object> map) {
+		return session.selectOne(NAMESPACE + "getCommentOrderById", map);
+	}
+
 }

--- a/src/main/java/com/my/ex/dao/IBoardDao.java
+++ b/src/main/java/com/my/ex/dao/IBoardDao.java
@@ -51,6 +51,9 @@ public interface IBoardDao {
 	int removeReplyIfNoChildReplies(Map<String, Integer> map);
 	int updateCommentStep(Map<String, Integer> map);
 	
+	// targetComment가 몇 번째에 위치하는지 확인
+	int getCommentOrderById(Map<String, Object> map);
+	
 	int boardCount();
 	int incrementCommentCount(int bGroup);
 	int decrementCommentCount(int bGroup);

--- a/src/main/java/com/my/ex/dao/INotificationDao.java
+++ b/src/main/java/com/my/ex/dao/INotificationDao.java
@@ -1,0 +1,14 @@
+package com.my.ex.dao;
+
+import java.util.List;
+import java.util.Map;
+
+import com.my.ex.dto.NotificationDto;
+
+public interface INotificationDao {
+	void addNotification(NotificationDto notificationDto);
+	List<NotificationDto> getNotifications(String userId);
+	List<NotificationDto> getAllNotifications(Map<String, Object> map);
+	int updateReadStatus(int notificationId);
+	int getUnreadCount(String userId);
+}

--- a/src/main/java/com/my/ex/dao/NotificationDao.java
+++ b/src/main/java/com/my/ex/dao/NotificationDao.java
@@ -1,0 +1,45 @@
+package com.my.ex.dao;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import com.my.ex.dto.NotificationDto;
+
+@Repository
+public class NotificationDao implements INotificationDao {
+
+	private final String NAMESPACE = "com.my.ex.NotificationMapper.";
+
+	@Autowired
+	private SqlSession session;
+
+	@Override
+	public void addNotification(NotificationDto notificationDto) {
+		session.insert(NAMESPACE + "addNotification", notificationDto);
+	}
+
+	@Override
+	public List<NotificationDto> getNotifications(String userId) {
+		return session.selectList(NAMESPACE + "getNotifications", userId);
+	}
+
+	@Override
+	public int updateReadStatus(int notificationId) {
+		return session.update(NAMESPACE + "updateReadStatus", notificationId);
+	}
+
+	@Override
+	public int getUnreadCount(String userId) {
+		return session.selectOne(NAMESPACE + "getUnreadCount", userId);
+	}
+
+	@Override
+	public List<NotificationDto> getAllNotifications(Map<String, Object> map) {
+		return session.selectList(NAMESPACE + "getAllNotifications", map);
+	}
+
+}

--- a/src/main/java/com/my/ex/dto/NotificationDto.java
+++ b/src/main/java/com/my/ex/dto/NotificationDto.java
@@ -1,0 +1,18 @@
+package com.my.ex.dto;
+
+import java.sql.Date;
+
+import lombok.Data;
+
+@Data
+public class NotificationDto {
+	private int notificationId;
+	private String userId; // 알림을 받을 사용자ID
+	private String type; // 알림 종류(좋아요, 댓글, 팔로우 등)
+	private int relatedId; // 알림과 관련된 주요 대상의 ID (예: 게시글 ID, 댓글 ID)
+	private String senderId; // 알림을 발생시킨 사용자ID
+	private String dataJson; // 댓글 미리 보기 내용 저장
+	private String link;
+	private String isRead;
+	private Date createdAt;
+}

--- a/src/main/java/com/my/ex/dto/NotificationResponseDto.java
+++ b/src/main/java/com/my/ex/dto/NotificationResponseDto.java
@@ -1,0 +1,12 @@
+package com.my.ex.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class NotificationResponseDto {
+	private List<NotificationDto> notificationDtos;
+	private int unreadCount;
+	private boolean readStatusUpdated;
+}

--- a/src/main/java/com/my/ex/service/BoardService.java
+++ b/src/main/java/com/my/ex/service/BoardService.java
@@ -7,10 +7,13 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.my.ex.dao.BoardDao;
 import com.my.ex.dto.BoardDto;
 import com.my.ex.dto.BoardPagingDto;
 import com.my.ex.dto.CommentsPagingDto;
+import com.my.ex.dto.NotificationDto;
 import com.my.ex.dto.PostTagDto;
 import com.my.ex.dto.TagDto;
 
@@ -25,6 +28,9 @@ public class BoardService implements IBoardService {
 	
 	@Autowired
 	private BoardDao dao;
+	
+	@Autowired
+	private NotificationService notificationService;
 	
 	@Override
 	public boolean createBoard(BoardDto dto) {
@@ -104,8 +110,47 @@ public class BoardService implements IBoardService {
 	}
 
 	@Override
-	public void replyInsert(BoardDto dto) {
+	public void replyInsert(BoardDto dto, NotificationDto notificationDto, int commentPage) {
 		dao.replyInsert(dto);
+		
+		// 댓글 작성자와 게시글 작성자가 다를 경우에만 알림 생성
+		if(!notificationDto.getUserId().equals(notificationDto.getSenderId())) {
+			int commentId = dto.getbId(); // 댓글 삽입 후 set된 댓글ID
+			
+			String commentSnippet = dto.getbContent().length() > 10 ? dto.getbContent().substring(0, 10) + "..." : dto.getbContent();
+			ObjectMapper mapper = new ObjectMapper();
+			String dataJsonString = null;
+			try {
+				Map<String, Object> dataMap = new HashMap<>();
+				dataMap.put("commentSnippet", commentSnippet);
+				dataMap.put("commentPage", commentPage);
+				dataJsonString = mapper.writeValueAsString(dataMap);
+			} catch (JsonProcessingException e) {
+				e.printStackTrace();
+			}
+			notificationDto.setDataJson(dataJsonString);
+			
+			notificationDto.setRelatedId(commentId);
+			notificationDto.setLink("/board/detailBoard?"
+					+ "bId=" + dto.getbGroup()
+					+ "&bGroup=" + dto.getbGroup() 
+					+ "&bName=" + notificationDto.getUserId() // 알림을 받을 사용자ID(게시글 작성자ID)
+					+ "&targetCommentId=" + commentId);
+			notificationService.addNotification(notificationDto);
+		}
+	}
+	
+	@Override
+	public int calculateCommentPage(Integer targetCommentId, int bGroup, int commentsPageLimit) {
+		// targetComment가 몇번째에 위치하는지 확인
+		Map<String, Object> map = new HashMap<>();
+		map.put("targetCommentId", targetCommentId);
+		map.put("bGroup", bGroup);
+		int commentOrder = dao.getCommentOrderById(map);
+		
+		// targetComment가 위치한 페이지 링크
+		int calculatedPage =(int) Math.ceil((double)commentOrder / COMMENTS_PAGE_LIMIT);
+		return calculatedPage;
 	}
 
 	@Override

--- a/src/main/java/com/my/ex/service/IBoardService.java
+++ b/src/main/java/com/my/ex/service/IBoardService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.my.ex.dto.BoardDto;
 import com.my.ex.dto.BoardPagingDto;
 import com.my.ex.dto.CommentsPagingDto;
+import com.my.ex.dto.NotificationDto;
 import com.my.ex.dto.TagDto;
 
 public interface IBoardService {
@@ -39,13 +40,16 @@ public interface IBoardService {
 	int decrementRecommendationAndGetCount(int bId);
 	
 	// 댓글 및 답글 등록, 삭제
-	void replyInsert(BoardDto dto);
+	void replyInsert(BoardDto dto, NotificationDto notificationDto, int commentPage);
 	void replyChildInsert(BoardDto dto);
 	int incrementCommentCount(int bGroup);
 	int decrementCommentCount(int bGroup);
 	boolean removeReply(Map<String, Object> map);
 	boolean updateCommentStep(Map<String, Integer> map);
 	boolean removeReplyIfNoChildReplies(Map<String, Integer> map);
+	
+	// 특정 댓글 ID에 해당하는 댓글이 현재 댓글 내에서 몇 번째 페이지에 위치하는지 계산
+	int calculateCommentPage(Integer targetCommentId, int bGroup, int commentsPageLimit);
 	
 	int getTotalBookmarks(int bId);
 	List<BoardDto> replyList(int bGroup);

--- a/src/main/java/com/my/ex/service/ILikeService.java
+++ b/src/main/java/com/my/ex/service/ILikeService.java
@@ -1,9 +1,10 @@
 package com.my.ex.service;
 
 import com.my.ex.dto.LikeDto;
+import com.my.ex.dto.NotificationDto;
 
 public interface ILikeService {
-	void addLike(LikeDto dto);
+	void addLike(LikeDto dto, NotificationDto notificationDto);
 	void removeLike(LikeDto dto);
 	boolean isLiked(int bId, String userId);
 	void addRecommend(LikeDto dto);

--- a/src/main/java/com/my/ex/service/INotificationService.java
+++ b/src/main/java/com/my/ex/service/INotificationService.java
@@ -1,0 +1,13 @@
+package com.my.ex.service;
+
+import java.util.List;
+
+import com.my.ex.dto.NotificationDto;
+
+public interface INotificationService {
+	void addNotification(NotificationDto notificationDto);
+	List<NotificationDto> getNotifications(String userId);
+	List<NotificationDto> getAllNotifications(String userId, int size, int offset);
+	boolean updateReadStatus(int notificationId);
+	int getUnreadCount(String userId);
+}

--- a/src/main/java/com/my/ex/service/LikeService.java
+++ b/src/main/java/com/my/ex/service/LikeService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import com.my.ex.dao.BoardDao;
 import com.my.ex.dao.LikeDao;
 import com.my.ex.dto.LikeDto;
+import com.my.ex.dto.NotificationDto;
 
 @Service
 public class LikeService implements ILikeService{
@@ -15,10 +16,18 @@ public class LikeService implements ILikeService{
 	
 	@Autowired
 	private BoardDao boardDao;
-
+	
+	@Autowired
+	private NotificationService notificationService;
+	
+	// 게시글 작성자가 아닌 사용자가 좋아요를 눌렀을 때만 알림 생성
 	@Override
-	public void addLike(LikeDto dto) {
+	public void addLike(LikeDto dto, NotificationDto notificationDto) {
 		dao.addLike(dto);
+		
+		if(!notificationDto.getUserId().equals(notificationDto.getSenderId())) {
+			notificationService.addNotification(notificationDto);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/my/ex/service/NotificationService.java
+++ b/src/main/java/com/my/ex/service/NotificationService.java
@@ -1,0 +1,50 @@
+package com.my.ex.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.my.ex.dao.NotificationDao;
+import com.my.ex.dto.NotificationDto;
+
+@Service
+public class NotificationService implements INotificationService {
+
+	@Autowired
+	private NotificationDao dao;
+
+	@Override
+	public void addNotification(NotificationDto notificationDto) {
+		dao.addNotification(notificationDto);
+	}
+
+	@Override
+	public List<NotificationDto> getNotifications(String userId) {
+		return dao.getNotifications(userId);
+	}
+
+	@Override
+	public boolean updateReadStatus(int notificationId) {
+		int result = dao.updateReadStatus(notificationId);
+		return result > 0;
+	}
+
+	@Override
+	public int getUnreadCount(String userId) {
+		return dao.getUnreadCount(userId);
+	}
+
+	@Override
+	public List<NotificationDto> getAllNotifications(String userId, int size, int offset) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("userId", userId);
+		map.put("size", size);
+		map.put("offset", offset);
+		
+		return dao.getAllNotifications(map);
+	}
+	
+}

--- a/src/main/resources/mappers/Boardmapper.xml
+++ b/src/main/resources/mappers/Boardmapper.xml
@@ -161,6 +161,10 @@
 	</select>
 	
 	<insert id="replyInsert" parameterType="BoardDto">
+		<selectKey keyProperty="bId" resultType="Integer" order="BEFORE">
+			SELECT seq_mvc_board6.NEXTVAL 
+			  FROM dual
+		</selectKey>
 		INSERT INTO mvc_board6
 			(
 			bId,
@@ -172,7 +176,7 @@
 			)
 		VALUES
 			(
-			seq_mvc_board6.nextval,
+			#{bId},
 			#{bName},
 			#{bContent},
 			#{bGroup},
@@ -180,6 +184,14 @@
 			#{bIndent} + 1
 			)
 	</insert>
+	
+	<select id="getCommentOrderById" parameterType="java.util.HashMap" resultType="Integer">
+		SELECT COUNT(bId) 
+		  FROM MVC_BOARD6
+		 WHERE bGroup = #{bGroup}
+		   AND bId <![CDATA[ >= ]]> #{targetCommentId}
+		   AND bStep > 0
+	</select>
 	
 	<update id="replyShape" parameterType="java.util.HashMap">
 		UPDATE mvc_board6

--- a/src/main/resources/mappers/Notificationmapper.xml
+++ b/src/main/resources/mappers/Notificationmapper.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.my.ex.NotificationMapper">
+	<insert id="addNotification" parameterType="NotificationDto">
+		INSERT INTO mvc_notifications6
+			(
+			notificationId,
+			userId,
+			type,
+			relatedId,
+			senderId,
+			data_json,
+			link
+			)
+		VALUES
+			(
+			seq_mvc_notification6.NEXTVAL,
+			#{userId},
+			#{type},
+			#{relatedId},
+			#{senderId},
+			#{dataJson},
+			#{link}
+			)
+	</insert>
+	
+	<select id="getNotifications" resultType="NotificationDto">
+		SELECT *
+		  FROM mvc_notifications6
+		 WHERE userId = #{userId}
+		   AND (
+		   	   is_read = 'N'
+		   	   OR created_at >= SYSTIMESTAMP - INTERVAL '3' DAY
+		   )
+		 ORDER BY is_read ASC, created_At DESC
+	</select>
+	
+	<select id="getAllNotifications" parameterType="java.util.HashMap" resultType="NotificationDto">
+		SELECT * FROM (
+		    SELECT a.*, ROWNUM rnum FROM (
+		        SELECT * FROM mvc_notifications6
+		        WHERE userId = #{userId}
+		        ORDER BY is_read ASC, created_At DESC
+		    ) a
+		    WHERE ROWNUM &lt;= #{offset} + #{size}
+		)
+		WHERE rnum &gt; #{offset}
+	</select>
+
+	<update id="updateReadStatus">
+		UPDATE mvc_notifications6
+		   SET is_read = 'Y'
+		 WHERE notificationId = #{notificationId}
+	</update>
+	
+	<select id="getUnreadCount" resultType="Integer">
+		SELECT COUNT(*)
+		  FROM mvc_notifications6
+		 WHERE userId = #{userId} 
+		   AND is_read = 'N'
+	</select>
+</mapper>

--- a/src/main/webapp/WEB-INF/views/board/createPage.jsp
+++ b/src/main/webapp/WEB-INF/views/board/createPage.jsp
@@ -50,6 +50,7 @@
 	<div class="hidden-data" id="errorbTitle" data-errorbTitle="${bTitle}"></div>
 	<div class="hidden-data" id="errorbAddress" data-errorbAddress="${bAddress}"></div>
 	<div class="hidden-data" id="errorTags" data-errortagJsonList="${fn:escapeXml(tagJsonList)}"></div>
+	<div class="hidden-data" id="userId" data-userId="${sessionScope.userId}"></div>
 	
 	<script src="<c:url value="/resources/js/createPage.js"/>"></script>
 	<script src="<c:url value="/resources/js/uploadAdapter.js"/>"></script>

--- a/src/main/webapp/WEB-INF/views/board/detailPage.jsp
+++ b/src/main/webapp/WEB-INF/views/board/detailPage.jsp
@@ -9,6 +9,9 @@
 <!-- 지도 표시 -->
 <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=${jsKey}&libraries=services"></script>
+
+<!-- axios -->
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 </head>
 <body>
 	<%@ include file="/WEB-INF/views/include/loginInfo.jsp" %>
@@ -204,7 +207,7 @@
 							
 								<!-- 댓글인 경우 -->
 								<c:if test="${comment.bIndent == 1}">
-									<article>
+									<article id="comment-${comment.bId}">
 										<c:choose>
 											<c:when test="${comment.bContent == '작성자가 삭제한 댓글입니다.'}">
 												<p class="post-content removeMessage">${comment.bContent}</p>
@@ -249,7 +252,7 @@
 								
 								<!-- 답글인 경우 -->
 								<c:if test="${comment.bIndent != 1}">
-									<article class="comment-child">
+									<article class="comment-child" id="comment-${comment.bId}">
 										<div class="user-info">
 											<div class="left-info">
 												<img id="profile-photo-${comment.bId} comment-child" src="${profileImageUrls[status.index]}" />
@@ -370,6 +373,8 @@
 	<div class="hidden-data" id="bId" data-bId="${dto.bId}"></div>
 	<div class="hidden-data" id="bTitle" data-bTitle="${dto.bTitle}"></div>
 	<div class="hidden-data" id="bContent" data-bContent="<c:out value='${dto.bContent}'/>"></div>
+	<div class="hidden-data" id="bName" data-bName="${dto.bName}"></div>
+	<div class="hidden-data" id="bGroup" data-bGroup="${dto.bGroup}"></div>
 	<div class="hidden-data" id="isLiked" data-isLiked="${isLiked}"></div>
 	<div class="hidden-data" id="isBookmarked" data-isBookmarked="${isBookmarked}"></div>
 	<div class="hidden-data" id="userNickname" data-userId="${sessionScope.userNickname}"></div>
@@ -403,11 +408,11 @@ const replyTable = document.querySelector(".comments")
 const replyInput = document.querySelector("#comment-input")
 const COMMENTS_PAGE_LIMIT = 6
 const COMMENTS_BLOCK_LIMIT = 3
-let currentPage = 1
+let currentcommentPage = 1
 
 	// 현재 페이지 블록
 const setPage = (page) => {
-	currentPage = page
+	currentcommentPage = page
 }
 
 	// 댓글 개수UI 업데이트
@@ -436,7 +441,7 @@ const editCommentTable = (replyList, profileImageUrls) => {
 			const formattedDate = formatDate(new Date(replyList[i].bDate))
 			
 			if(replyList[i].bIndent == 1){ // 댓글
-			output += `<article>`
+			output += `<article id="comment-\${replyList[i].bId}">`
 				if(replyList[i].bContent == removeMessage) {
 					output += `<p class="post-content removeMessage">\${replyList[i].bContent}</p>`
 				} else {
@@ -476,7 +481,7 @@ const editCommentTable = (replyList, profileImageUrls) => {
 				}
 				output += `</article>`
 			} else { // 답글
-				output += `<article class="comment-child">
+				output += `<article class="comment-child" id="comment-\${replyList[i].bId}">
 								<div class="user-info">
 									<div class="left-info">
 										<img id="profile-photo-\${replyList[i].bId} comment-child" src="\${profileImageUrls[i]}" />
@@ -640,7 +645,6 @@ const ajaxBlockLink  = () => {
 		})
 	})
 }
-
 	// 댓글 버튼 리스너
 replyBtn.addEventListener('click', function(){
 	let replyInputValue = replyInput.value
@@ -652,8 +656,9 @@ replyBtn.addEventListener('click', function(){
 			type: "post",
 			url: "/board/replyInsert",
 			data: {
-				page: currentPage,
+				page: currentcommentPage,
 				bId: "${dto.bId}",
+				boardWriterId: "${dto.bName}",
 				bContent: replyInputValue,
 				bGroup: "${dto.bGroup}",
 				bStep: "${dto.bStep}",
@@ -703,7 +708,7 @@ function registerEventListeners(){
                     	type: "post",
                     	url: "replyChildInsert",
                     	data: {
-                    		page: currentPage,
+                    		page: currentcommentPage,
                     		bContent: bContent,
                     		bGroup: bGroup,
                     		bStep: bStep,
@@ -816,7 +821,7 @@ const commentRemove = (bId, bGroup, bStep, bIndent) => {
 		type: "post",
 		url: "/board/removeReply",
 		data: {
-			page: currentPage,
+			page: currentcommentPage,
 			bId: bId,
 			bGroup: bGroup,
 			bStep: bStep,
@@ -839,7 +844,7 @@ const commentChildRemove = (bId, bGroup, bStep) => {
 		type: "post",
 		url: "/board/removeChildReply",
 		data: {
-			page: currentPage,
+			page: currentcommentPage,
 			bId: bId,
 			bGroup: bGroup,
 			bStep: bStep

--- a/src/main/webapp/WEB-INF/views/board/pagingList.jsp
+++ b/src/main/webapp/WEB-INF/views/board/pagingList.jsp
@@ -16,6 +16,7 @@
 	var searchText = "${param.searchText}"
     var sortType = ("${param.sortType}" == "") ? "latest" : "${param.sortType}"
 </script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 </head>
 <body>
 	<%@ include file="/WEB-INF/views/include/loginInfo.jsp" %>

--- a/src/main/webapp/WEB-INF/views/category/contact.jsp
+++ b/src/main/webapp/WEB-INF/views/category/contact.jsp
@@ -83,5 +83,6 @@
     </div>
 	
 	<%@ include file="/WEB-INF/views/include/footer.jsp" %>
+	<div class="hidden-data" id="userId" data-userId="${sessionScope.userId}"></div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/category/weather.jsp
+++ b/src/main/webapp/WEB-INF/views/category/weather.jsp
@@ -8,6 +8,9 @@
 
 <!-- ckeditor -->
 <%-- <script src="${pageContext.request.contextPath}/resources/static/ckeditor/build/ckeditor.js"></script> --%>
+
+<!-- axios -->
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 </head>
 <body>
 	<%@ include file="/WEB-INF/views/include/loginInfo.jsp" %>
@@ -34,6 +37,9 @@
 </body>
 <div class="hidden-data" id="latitude" data-latitude="${sessionScope.latitude}"></div>
 <div class="hidden-data" id="longitude" data-longitude="${sessionScope.longitude}"></div>
+<div class="hidden-data" id="userId" data-userId="${sessionScope.userId}"></div>
+<div class="hidden-data" id="userNickname" data-userNickname="${sessionScope.userNickname}"></div>
+<div class="hidden-data" id="contextPath" data-context-path="${pageContext.request.contextPath}"></div>
 
 <script src="<c:url value="/resources/js/common.js"/>"></script>
 <script src="<c:url value="/resources/js/weather.js"/>"></script>

--- a/src/main/webapp/WEB-INF/views/include/loginInfo.jsp
+++ b/src/main/webapp/WEB-INF/views/include/loginInfo.jsp
@@ -35,8 +35,31 @@
 								</li>
 							</ul>
 						</div>
+						
 						<div class="col-md-6 header-welcomeText">
-							<h5 id="welcomeText"></h5>
+							<div>
+								<!-- 알림 아이콘 -->
+								<span id="notificationIconWrapper">
+									<i class="fas fa-bell"></i>
+									<span id="notificationBadge"></span>
+								</span>
+								<!-- 알림 아이콘 end -->
+							
+								<!-- 알림 모달창 -->
+								<div id="notificationModal" class="notification-modal">
+							        <div class="notification-header">
+							            <h3>알림</h3>
+							            <span class="close-modal-btn">&times;</span>
+							        </div>
+							        <ul class="notification-list"></ul>
+							        <div class="notification-footer">
+							            <a href="/notification/getAllNotifications">모든 알림 보기</a>
+							        </div>
+							    </div>
+								<!-- 알림 모달창 end -->
+							
+								<h5 id="welcomeText"></h5>
+							</div>
 <%-- 							<a class="menubar-button-primary" id="loginLogoutLink" href="${empty sessionScope.userId ? --%>
 <%-- 														  '/user/loginPage' :  --%>
 <%-- 														  '/user/logout'}"  --%>

--- a/src/main/webapp/WEB-INF/views/user/getNotifications.jsp
+++ b/src/main/webapp/WEB-INF/views/user/getNotifications.jsp
@@ -1,0 +1,31 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ include file="/WEB-INF/views/include/header.jsp" %>
+<link href="<c:url value="/resources/css/getNotifications.css"/>" rel="stylesheet">
+
+<!-- axios -->
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+</head>
+<body>
+	<%@ include file="/WEB-INF/views/include/loginInfo.jsp" %>
+	
+	<main class="my-posts-main">
+		<div class="my-posts-container">
+			<ul class="noti-list"></ul>
+			<div class="spinner-grow spinner-grow-sm"></div>
+		</div>			
+	</main>
+	
+	<%@ include file="/WEB-INF/views/include/footer.jsp" %>
+	
+	<div class="hidden-data" id="userId" data-userId="${sessionScope.userId}"></div>
+	<div class="hidden-data" id="userNickname" data-userNickname="${sessionScope.userNickname}"></div>
+	<div class="hidden-data" id="notificationAllList" 
+		data-notificationAllList='${fn:escapeXml(notificationAllListJson)}'>
+	</div>
+	
+	<script src="<c:url value="/resources/js/getNotifications.js"/>"></script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/user/getUserComments.jsp
+++ b/src/main/webapp/WEB-INF/views/user/getUserComments.jsp
@@ -2,6 +2,9 @@
     pageEncoding="UTF-8"%>
 <%@ include file="/WEB-INF/views/include/header.jsp" %>
 <link href="<c:url value="/resources/css/getUserPosts.css"/>" rel="stylesheet">
+
+<!-- axios -->
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 </head>
 <body>
 	<%@ include file="/WEB-INF/views/include/loginInfo.jsp" %>

--- a/src/main/webapp/WEB-INF/views/user/getUserLikedPosts.jsp
+++ b/src/main/webapp/WEB-INF/views/user/getUserLikedPosts.jsp
@@ -3,6 +3,9 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ include file="/WEB-INF/views/include/header.jsp" %>
 <link href="<c:url value="/resources/css/getUserPosts.css"/>" rel="stylesheet">
+
+<!-- axios -->
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 </head>
 <body>
 	<%@ include file="/WEB-INF/views/include/loginInfo.jsp" %>

--- a/src/main/webapp/WEB-INF/views/user/myPage.jsp
+++ b/src/main/webapp/WEB-INF/views/user/myPage.jsp
@@ -4,6 +4,9 @@
 <%@ include file="/WEB-INF/views/include/header.jsp" %>
 <link href="<c:url value="/resources/css/myPage.css"/>" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Inter&display=swap" rel="stylesheet" />
+
+<!-- axios -->
+<script type="module" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 </head>
 <body>
 	<%@ include file="/WEB-INF/views/include/loginInfo.jsp" %>

--- a/src/main/webapp/resources/css/common.css
+++ b/src/main/webapp/resources/css/common.css
@@ -412,111 +412,111 @@ h1 span{
 	transform: translate(0);
 }
 
-h1 span:nth-child(1){
-	opacity: 0;
-	transform: translateY(-20px);
-}
-body.hero-anime h1 span:nth-child(2){
-	opacity: 0;
-	transform: translateY(-30px);
-}
-body.hero-anime h1 span:nth-child(3){
-	opacity: 0;
-	transform: translateY(-50px);
-}
-body.hero-anime h1 span:nth-child(4){
-	opacity: 0;
-	transform: translateY(-10px);
-}
-body.hero-anime h1 span:nth-child(5){
-	opacity: 0;
-	transform: translateY(-50px);
-}
-body.hero-anime h1 span:nth-child(6){
-	opacity: 0;
-	transform: translateY(-20px);
-}
-body.hero-anime h1 span:nth-child(7){
-	opacity: 0;
-	transform: translateY(-40px);
-}
-body.hero-anime h1 span:nth-child(8){
-	opacity: 0;
-	transform: translateY(-10px);
-}
-body.hero-anime h1 span:nth-child(9){
-	opacity: 0;
-	transform: translateY(-30px);
-}
-body.hero-anime h1 span:nth-child(10){
-	opacity: 0;
-	transform: translateY(-20px);
-}
-h1 span:nth-child(1){
-    transition-delay: 1000ms;
-}
-h1 span:nth-child(2){
-    transition-delay: 700ms;
-}
-h1 span:nth-child(3){
-    transition-delay: 900ms;
-}
-h1 span:nth-child(4){
-    transition-delay: 800ms;
-}
-h1 span:nth-child(5){
-    transition-delay: 1000ms;
-}
-h1 span:nth-child(6){
-    transition-delay: 700ms;
-}
-h1 span:nth-child(7){
-    transition-delay: 900ms;
-}
-h1 span:nth-child(8){
-    transition-delay: 800ms;
-}
-h1 span:nth-child(9){
-    transition-delay: 600ms;
-}
-h1 span:nth-child(10){
-    transition-delay: 700ms;
-}
-body.hero-anime h1 span:nth-child(11){
-	opacity: 0;
-	transform: translateY(30px);
-}
-body.hero-anime h1 span:nth-child(12){
-	opacity: 0;
-	transform: translateY(50px);
-}
-body.hero-anime h1 span:nth-child(13){
-	opacity: 0;
-	transform: translateY(20px);
-}
-body.hero-anime h1 span:nth-child(14){
-	opacity: 0;
-	transform: translateY(30px);
-}
-body.hero-anime h1 span:nth-child(15){
-	opacity: 0;
-	transform: translateY(50px);
-}
-h1 span:nth-child(11){
-    transition-delay: 1300ms;
-}
-h1 span:nth-child(12){
-    transition-delay: 1500ms;
-}
-h1 span:nth-child(13){
-    transition-delay: 1400ms;
-}
-h1 span:nth-child(14){
-    transition-delay: 1200ms;
-}
-h1 span:nth-child(15){
-    transition-delay: 1450ms;
-}
+/* h1 span:nth-child(1){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-20px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(2){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-30px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(3){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-50px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(4){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-10px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(5){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-50px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(6){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-20px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(7){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-40px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(8){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-10px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(9){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-30px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(10){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(-20px); */
+/* } */
+/* h1 span:nth-child(1){ */
+/*     transition-delay: 1000ms; */
+/* } */
+/* h1 span:nth-child(2){ */
+/*     transition-delay: 700ms; */
+/* } */
+/* h1 span:nth-child(3){ */
+/*     transition-delay: 900ms; */
+/* } */
+/* h1 span:nth-child(4){ */
+/*     transition-delay: 800ms; */
+/* } */
+/* h1 span:nth-child(5){ */
+/*     transition-delay: 1000ms; */
+/* } */
+/* h1 span:nth-child(6){ */
+/*     transition-delay: 700ms; */
+/* } */
+/* h1 span:nth-child(7){ */
+/*     transition-delay: 900ms; */
+/* } */
+/* h1 span:nth-child(8){ */
+/*     transition-delay: 800ms; */
+/* } */
+/* h1 span:nth-child(9){ */
+/*     transition-delay: 600ms; */
+/* } */
+/* h1 span:nth-child(10){ */
+/*     transition-delay: 700ms; */
+/* } */
+/* body.hero-anime h1 span:nth-child(11){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(30px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(12){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(50px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(13){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(20px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(14){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(30px); */
+/* } */
+/* body.hero-anime h1 span:nth-child(15){ */
+/* 	opacity: 0; */
+/* 	transform: translateY(50px); */
+/* } */
+/* h1 span:nth-child(11){ */
+/*     transition-delay: 1300ms; */
+/* } */
+/* h1 span:nth-child(12){ */
+/*     transition-delay: 1500ms; */
+/* } */
+/* h1 span:nth-child(13){ */
+/*     transition-delay: 1400ms; */
+/* } */
+/* h1 span:nth-child(14){ */
+/*     transition-delay: 1200ms; */
+/* } */
+/* h1 span:nth-child(15){ */
+/*     transition-delay: 1450ms; */
+/* } */
 #switch,
 #circle {
 	cursor: pointer;
@@ -609,63 +609,241 @@ body.hero-anime #switch{
 	background-color: #ad9f94;
 }
 
-body.dark{
-	color: #fff;
-	background-color: #1f2029;
-}
-body.dark .navbar-brand img{
-    filter: brightness(100%);
-}
-body.dark h1{
-	color: #fff;
-}
-body.dark h1 span{
-    transition-delay: 0ms !important;
-}
-body.dark p{
-	color: #fff;
-    transition-delay: 0ms !important;
-}
-body.dark .bg-light {
-	background-color: #14151a !important;
-}
-body.dark .start-header {
-	box-shadow: 0 10px 30px 0 rgba(0, 0, 0, 0.15);
-}
-body.dark .start-header.scroll-on {
-	box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.15);
-}
-body.dark .nav-link{
-	color: #fff !important;
-}
-body.dark .nav-item.active .nav-link{
-	color: #999 !important;
-}
-body.dark .dropdown-menu {
-	color: #fff;
-	background-color: #1f2029;
-	box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.25);
-}
-body.dark .dropdown-item {
-	color: #fff;
-}
-body.dark .navbar-light .navbar-toggler-icon {
-	border-bottom: 1px solid #fff;
-}
-body.dark .navbar-light .navbar-toggler-icon:after, 
-body.dark .navbar-light .navbar-toggler-icon:before{
-	background-color: #fff;
-}
-body.dark .navbar-toggler[aria-expanded="true"] .navbar-toggler-icon {
-	border-color: transparent;
-}
-
 hr {
     padding: 0;
     height: 1px;
     border: none;
     background-color: #EAEDEF;
     margin-top: 20px;
+}
+
+/* 알림 아이콘
+================================================== */
+#notificationIconWrapper {
+	margin-left: 10px; 
+	position: relative; 
+	cursor: pointer;
+}
+
+#notificationIconWrapper #notificationBadge {
+	position: absolute;
+	top: -10px;
+	right: -8px;
+	background-color: red;
+	color: white;
+	border-radius: 50%;
+	padding: 2px 6px;
+	font-size: 9px;
+	min-width: 15px;
+	text-align: center;
+	display: none; /* 초기에는 숨김 */
+}
+
+.fas.fa-bell {
+	font-size: 20px; 
+	color: #333;
+}
+
+/* 알림 아이콘 클릭치 띄울 모달창
+================================================== */
+.notification-modal {
+    display: none;
+    position: absolute;
+    top: 40px;
+    right: 0;
+    width: 380px;
+    background-color: #f5f5f5;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    overflow: hidden;
+}
+
+.notification-modal.show {
+    display: block;
+}
+
+.notification-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 20px;
+    border-bottom: 1px solid #eee;
+    background-color: #fbfbfb;
+}
+
+.notification-header h3 {
+    margin: 0;
+    font-size: 18px;
+    color: #333;
+    font-weight: 600;
+}
+
+.close-modal-btn {
+    font-size: 24px;
+    color: #999;
+    cursor: pointer;
+    transition: color 0.2s ease;
+}
+
+.close-modal-btn:hover {
+    color: #333;
+}
+
+.notification-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    max-height: 300px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.no-notifications {
+    padding: 50px;
+    text-align: center;
+    color: #888;
+    font-size: 14px;
+}
+
+/* 알림 항목 <li> */
+.notification-item {
+    background-color: #ffffff;
+    border-bottom: 1px solid #eee;
+    transition: background-color 0.2s ease;
+}
+
+.notification-item.unread {
+    background-color: #eaf6ff;
+    border-bottom: 1px solid #d4eafc;
+}
+
+.notification-item:last-child {
+    border-bottom: none;
+}
+
+/* 알림 항목 내부 링크 */
+.notification-item a {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 15px 20px;
+    text-decoration: none;
+    color: inherit;
+    width: 100%;
+    box-sizing: border-box;
+    transition: background-color 0.2s ease;
+}
+
+/* 읽은 알림의 hover 효과 */
+.notification-item a:hover {
+    background-color: #f8f8f8;
+}
+
+/* 읽지 않은 알림의 hover 효과 */
+.notification-item.unread a:hover {
+    background-color: #dbeeff;
+}
+
+/* 알림 내용 영역 */
+.notification-content {
+    flex-grow: 1;
+    flex-shrink: 1; /* 필요시 축소 허용 */
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+/* 메인 알림 텍스트 */
+.notification-main-text {
+    font-size: 15px;
+    color: #333;
+    line-height: 1.4;
+}
+
+.notification-main-text strong {
+    color: #333;
+    font-weight: 600;
+}
+
+/* 댓글 미리보기 텍스트 */
+.comment-preview-text {
+    font-style: normal;
+    color: #555;
+    margin-top: 4px;
+    display: block; /* 새 줄에서 시작 */
+    font-size: 13px;
+    text-align: left;
+    white-space: nowrap; /* 한 줄로 표시 */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+}
+
+/* 시간과 뱃지 컨테이너 */
+.notification-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: flex-end;
+    margin-left: 15px;
+    flex-shrink: 0; /* 이 영역이 줄어들지 않도록 */
+}
+
+/* 알림 시간 */
+.notification-time {
+    font-size: 12px;
+    color: #999;
+    white-space: nowrap;
+}
+
+/* 'N' 뱃지 */
+.new-badge {
+    background-color: tomato;
+    color: white;
+    border-radius: 50%;
+    padding: 2px 6px;
+    font-size: 10px;
+    min-width: 15px;
+    text-align: center;
+    margin-top: 5px;
+    flex-shrink: 0;
+    align-self: flex-end;
+    height: 18px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.notification-info-message {
+	text-align: center;
+	color: #888;
+	font-size: 12px;
+	padding: 10px 0;
+	border-top: 1px solid #eee;
+}
+
+/* 모달 푸터 */
+.notification-footer {
+	display: none;
+    padding: 15px 20px;
+    text-align: center;
+    border-top: 1px solid #eee;
+    background-color: #fbfbfb;
+}
+
+.notification-footer a {
+    text-decoration: none;
+    color: #007bff;
+    font-size: 14px;
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+.notification-footer a:hover {
+    color: #0056b3;
 }
 
 /* .buttonn-primary
@@ -1267,9 +1445,9 @@ body.dark .logo img {
 
 .item.me .unread-indicator {
     right: 12%;
-    transform: translateX(calc(100% + 5px)); /* '1' 크기만큼 이동 + 약간의 간격 */
+    transform: translateX(calc(100% + 5px)); '1' 크기만큼 이동 + 약간의 간격
     bottom: 0;
-    white-space: nowrap; /* '1'이 줄바꿈 되지 않도록 */
+    white-space: nowrap; '1'이 줄바꿈 되지 않도록
 }
 
 /* 데이터 전달용 <div> 숨기기

--- a/src/main/webapp/resources/css/detailPage.css
+++ b/src/main/webapp/resources/css/detailPage.css
@@ -497,6 +497,7 @@ p.removeMessage {
 
 	/* 댓글 내용 */
 p.post-content {
+	word-wrap: break-word;
     font-size: 15px;
     line-height: 1.6;
     margin: 0 0 8px 0;
@@ -684,6 +685,14 @@ span.page-link {
     color: #fff !important;
     border-color: #ad9f94 !important;
     cursor: default !important;
+}
+
+/* 댓글 알림 클릭 시 해당 댓글 하이라이트
+ ================================================== */
+.highlight-comment {
+	background-color: #fff8c6;
+	border-left: 4px solid #ffd54f;
+	transition: background-color 0.7s ease;
 }
 
 /* 반응형 모바일

--- a/src/main/webapp/resources/css/getNotifications.css
+++ b/src/main/webapp/resources/css/getNotifications.css
@@ -1,0 +1,159 @@
+@charset "UTF-8";
+
+/* 전체 페이지 스타일 */
+body {
+    font-family: 'Noto Sans KR', sans-serif;
+    background-color: #f4f5f7;
+    color: #333;
+    line-height: 1.6;
+}
+
+/* 메인 컨텐츠 영역 */
+.my-posts-main {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 60px 20px;
+    min-height: calc(100vh - 120px);
+    box-sizing: border-box;
+}
+
+.my-posts-container {
+    width: 100%;
+    max-width: 800px;
+    background-color: #fff;
+    border-radius: 10px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
+    padding: 30px;
+    box-sizing: border-box;
+}
+
+/* 알림 목록 <ul> */
+.noti-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+/* 개별 알림 항목 <li> */
+.noti-item {
+    border-bottom: 1px solid #fff;
+    padding: 15px 10px;
+}
+
+.noti-item:last-child {
+    border-bottom: none;
+}
+
+.noti-item a {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: inherit;
+    text-decoration: none;
+    width: 100%;
+}
+
+/* 읽지 않은 알림 스타일 */
+.noti-item.unread {
+    background-color: #eaf6ff;
+}
+
+/* 알림 내용 */
+.noti-content {
+    flex-grow: 1;
+    margin-right: 15px;
+}
+
+.noti-content .sender-name {
+    font-weight: bold;
+    color: #2c3e50;
+    margin-right: 5px;
+}
+
+.noti-content .comment-preview-text {
+    display: block;
+    font-size: 0.9em;
+    color: #777;
+    margin-top: 5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap; /* 기본적으로 한 줄로 표시하고 ... 처리 */
+}
+
+/* 알림 메타 정보 */
+.noti-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    color: #999;
+    font-size: 0.85em;
+}
+
+.noti-meta .notification-time {
+    margin-bottom: 5px;
+}
+
+.noti-meta .new-badge {
+    background-color: tomato;
+    color: #fff;
+    font-size: 0.7em;
+    font-weight: bold;
+    border-radius: 5px;
+    padding: 3px 8px;
+}
+
+/* 호버 효과 */
+.noti-item a:hover {
+    background-color: #f8f8f8;
+}
+
+.noti-item.unread a:hover {
+    background-color: #dbeeff;
+}
+
+/* 알림 없음 메시지 */
+.no-noti {
+    text-align: center;
+    padding: 40px 20px;
+    color: #888;
+    font-size: 1em;
+}
+
+.spinner-grow {
+	display: none;
+	position: absolute;
+	top: calc(100% + 30px); /* ul 바로 아래 10px 간격 */
+	left: 50%;
+}
+
+.spinner-grow.show {
+	display: block;
+}
+
+.no-more-notifications {
+    text-align: center;
+    color: #666;
+    padding: 10px 0;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+    .my-posts-container {
+        padding: 20px;
+    }
+
+    .noti-item a {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .noti-content {
+        margin-bottom: 10px;
+        margin-right: 0;
+    }
+
+    .noti-meta {
+        align-items: flex-start;
+    }
+}

--- a/src/main/webapp/resources/js/detailPage.js
+++ b/src/main/webapp/resources/js/detailPage.js
@@ -223,9 +223,42 @@ if(address) {
 	addressInfo.innerHTML = `<div>${address}</div>`
 } 
 
+/* URL 쿼리스트링에서 targetCommentId를 추출하고, 해당 댓글로 스크롤 및 하이라이트 효과를 적용
+================================================== */
+const scrollToTargetComment = () => {
+	const urlParams = new URLSearchParams(window.location.search) // URL의 ?부터 시작하는 쿼리 문자열 전체 중 key-value로 다룰 수 있게 해줌
+	const targetCommentId = urlParams.get('targetCommentId')
+	if(targetCommentId){
+		const commentElement = document.querySelector(`#comment-${targetCommentId}`)
+
+		if(commentElement){
+			setTimeout(() => {
+				// 스크롤 동작
+				commentElement.scrollIntoView({
+					behavior: 'smooth',
+					block: 'center'
+				})
+
+				// 하이라이트 스타일
+				commentElement.classList.add('highlight-comment')
+
+				// 일정 시간 뒤에 하이라이트 제거
+				setTimeout(() => {
+					commentElement.classList.remove('highlight-comment')
+				}, 3000)
+			}, 300)
+		} else {
+			console.warn(`댓글 ID ${targetCommentId}에 해당하는 요소가 없습니다.`)
+		}
+	}
+}
+
 /* 페이지 로드 시 실행될 함수
 ================================================== */
-renderImages()
-closeModal()
-hideChatButton()
-hideDropdownMenu()
+document.addEventListener('DOMContentLoaded', () => {
+	renderImages()
+	closeModal()
+	hideChatButton()
+	hideDropdownMenu()
+	scrollToTargetComment()
+})

--- a/src/main/webapp/resources/js/fixedButton.js
+++ b/src/main/webapp/resources/js/fixedButton.js
@@ -1,6 +1,8 @@
 const activeClass = "fa-solid" // ♥
 const inactiveClass = "fa-regular" // ♡
 const bId = document.querySelector("#bId").getAttribute("data-bId")
+const bName = document.querySelector("#bName").getAttribute("data-bName")
+const bGroup = document.querySelector("#bGroup").getAttribute("data-bGroup")
 
 /* 좋아요
 ================================================== */
@@ -41,7 +43,9 @@ likeBtn.addEventListener('click', function(){
         $.ajax({
 			type: "post",
 			data: {
-				bId: bId 
+				bId: bId,
+				bName: bName,
+				bGroup: bGroup
 			},
 			url: "/board/addLike",
 			success: function(data){

--- a/src/main/webapp/resources/js/getNotifications.js
+++ b/src/main/webapp/resources/js/getNotifications.js
@@ -1,0 +1,231 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+    const notificationListJson = document.querySelector("#notificationAllList").getAttribute("data-notificationAllList")
+    const container = document.querySelector(".noti-list") // <ul>
+    const spinner = document.querySelector(".spinner-grow")
+
+    // 상대적인 시간으로 변환
+    const timeAgo = (timestamp) => {
+        const now = new Date()
+        const diff = now - timestamp // 얼마나 시간이 지났는지
+
+        const seconds = Math.floor(diff / 1000)
+        const minutes = Math.floor(seconds / 60)
+        const hours = Math.floor(minutes / 60)
+        const days = Math.floor(hours / 24)
+
+        if(seconds < 60){
+            return "방금 전"
+        } else if(minutes < 60){
+            return `${minutes}분 전`
+        } else if(hours < 60){
+            return `${hours}시간 전`
+        } else if(days < 7){
+            return `${days}일 전`
+        } else {
+            const year = timestamp.getFullYear()
+            const month = String(timestamp.getMonth() + 1).padStart(2, '0')
+            const day = String(timestamp.getDate()).padStart(2, '0')
+
+            return `${year}-${month}-${day}`
+        }
+    }
+
+    // 알림 목록 UI 업데이트
+    const renderNotificationList = (notificationList) => {
+        let output = ''
+
+        notificationList.forEach((notificationDto) => {
+            // 상대적인 시간으로 변환
+            const timestamp = new Date(notificationDto.createdAt)
+            const date = timeAgo(timestamp)
+
+            // 읽음 여부 표시 클래스
+            let readClass = notificationDto.isRead == 'N' ? 'unread' : ''
+
+            // type이 댓글인 경우 미리보기로 보여줄 내용
+            let commentSnippet = ''
+
+            // 알림 메시지
+            let notificationText = ''
+
+            if(notificationDto.type == 'LIKE'){
+                notificationText = 
+                `
+                    <strong class="sender-name">${notificationDto.senderId}</strong>님이 게시글을 좋아합니다.
+                `
+            } else if(notificationDto.type == 'COMMENT'){
+                const data = JSON.parse(notificationDto.dataJson)
+                commentSnippet = data.commentSnippet 
+                notificationText = 
+                `
+                    <strong class="sender-name">${notificationDto.senderId}</strong>님이 댓글을 달았습니다:<br/>
+                    <span class="comment-preview-text">${commentSnippet}</span>
+                `
+            }
+
+            output += 
+            `
+                <li class="noti-item ${readClass}">
+					<a href="${notificationDto.link}" data-notification-id="${notificationDto.notificationId}">
+						<div class="noti-content">
+							<span class="noti-main-text">${notificationText}</span>
+						</div>
+						<div class="noti-meta">
+							<span class="notification-time">${date}</span>
+							${readClass ? '<span class="new-badge">N</span>' : ''}
+						</div>
+					</a>
+				</li>
+            `
+        })
+
+        return output
+    }
+
+    // 상단 메뉴바에 있는 알림 아이콘의 count 및 스타일 업데이트
+	const badge = document.querySelector("#notificationBadge")
+	const showUnreadCount = (unreadCount) => {
+		if(unreadCount > 0){
+			badge.style.display = 'block'
+			badge.textContent = unreadCount
+		} else {
+			badge.style.display = 'none'
+			badge.textContent = ''
+		}
+	}
+
+    // 클릭 시 읽음 처리
+    const handleNotificationClick = () => {
+        const aElements = container.querySelectorAll("a")
+        aElements.forEach((aElement) => {
+            aElement.addEventListener('click', (e) => {
+                e.preventDefault()
+
+                const liElement = aElement.closest(".noti-item")
+                const notificationId = aElement.getAttribute("data-notification-id")
+                const href = aElement.getAttribute("href")
+
+                // 안 읽음 상태일 때만 서버로 읽음 처리 요청
+                if(liElement.classList.contains('unread')){
+                    const data = {
+                        notificationId: notificationId,
+                    }
+                    
+                    axios.patch('/notification/updateReadStatus', data)
+                        .then(response => {
+                            const updateResult = response.data.readStatusUpdated
+                            const unreadCount = response.data.unreadCount
+                            if(updateResult){
+                                liElement.classList.remove('unread')
+                                showUnreadCount(unreadCount)
+                            }
+                        })
+                        .catch(error => {
+                            console.error('error: ', error)
+                        })
+                } 
+                window.location.href = href
+            })
+        })
+    }
+
+    // 스피너 보여주기
+    const showSpinner = () => {
+        spinner.classList.add('show')
+    }
+
+    // 스피너 숨김
+    const hideSpinner = () => {
+        spinner.classList.remove('show')
+    }
+
+    // 다음 알림 데이터 불러오기
+    const loadMoreNotifications = (page, observer) => {
+        const params = {
+            page: page,
+            size: 10
+        }
+        
+        // 옵저버 종료 후 데이터 없음 알림 메시지
+        const handleNoMoreNotifications = () => {
+            if(!document.querySelector(".no-more-notifications")){
+                const noMoreMessage = 
+                `
+                    <li class="no-more-notifications">더 이상 알림이 없습니다.</li>
+                `
+                container.insertAdjacentHTML('beforeend', noMoreMessage)
+            }
+            observer.disconnect()  
+        }
+
+        axios.get('/notification/getAllNotifications/axios', { params })
+            .then(response => {
+                const notificationList = response.data
+                if(notificationList.length > 0){
+                    let output = renderNotificationList(notificationList)
+                    container.insertAdjacentHTML('beforeend', output)
+
+                    // 받은 데이터가 요청한 size보다 작으면 더 이상 데이터 없으므로 옵저버 종료
+                    if(notificationList.length < params.size){
+                        handleNoMoreNotifications()
+                    }
+                } else {
+                    // 더 이상 불러올 알림이 없을 경우
+                    handleNoMoreNotifications()
+                }
+
+                handleNotificationClick()
+            })
+            .catch(error => {
+                console.error('error: ', error)
+            })
+            .finally(() => {
+                hideSpinner()
+            })
+    }
+
+    // 무한 스크롤
+    const initInfiniteScrollObserver = () => {
+        let page = 2
+        const sentinel = document.querySelector("#scroll-sentinel")
+
+        // 옵저버 등록
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                if(entry.isIntersecting){
+                    showSpinner()
+
+                    setTimeout(() => {
+                        loadMoreNotifications(page, observer)
+                        page++
+                    }, 1000)
+                }
+            })
+        })
+
+        observer.observe(sentinel)
+    }
+
+    const notificationList = JSON.parse(notificationListJson)
+    container.innerHTML = '' // 초기화
+    let output = ''
+    
+    if(notificationList.length > 0 && container){
+        output = renderNotificationList(notificationList)
+        output += 
+        `
+            <div id="scroll-sentinel"></div>
+        `
+    } else {
+        output = 
+        `
+            <li class="no-noti">알림 내역이 없습니다.</li>
+        `
+    }
+    
+    container.innerHTML = output
+
+    initInfiniteScrollObserver()
+    handleNotificationClick()
+})

--- a/src/main/webapp/resources/js/loginInfo.js
+++ b/src/main/webapp/resources/js/loginInfo.js
@@ -43,4 +43,204 @@
 		}
 	});  
 	
-  })(jQuery); 
+})(jQuery); 
+
+document.addEventListener('DOMContentLoaded', () => {
+    const userId = document.querySelector("#userId").getAttribute("data-userId")
+	const notificationIcon = document.querySelector("#notificationIconWrapper")
+	const notificationModal = document.querySelector("#notificationModal")
+
+	// 모달 외부 클릭 시 모달 닫기
+	document.addEventListener('click', (event) => {
+		if(notificationModal.classList.contains('show') &&
+			!notificationModal.contains(event.target) &&
+			!notificationIcon.contains(event.target)
+		){
+			notificationModal.classList.remove('show')
+		}
+	})
+
+	// 상대적인 시간으로 변환
+	const timeAgo = (timestamp) => {
+		const now = new Date() // 현재 시간
+		const diff = now - timestamp // 얼마나 시간이 지났는지
+
+		const seconds = Math.floor(diff / 1000) 
+		const minutes = Math.floor(seconds / 60)
+		const hour = Math.floor(minutes / 60)
+		const days = Math.floor(hour / 24)
+
+		if(seconds < 60){
+			return "방금 전"
+		} else if(minutes < 60){
+			return `${minutes}분 전`
+		} else if(hour < 24){
+			return `${hour}시간 전`
+		} else if(days < 7){
+			return `${days}일 전`
+		} else {
+			// 오래된 경우 날짜 포맷으로 표시
+			const year = timestamp.getFullYear()
+			const month = String(timestamp.getMonth() + 1).padStart(2, '0')
+			const day = String(timestamp.getDate()).padStart(2, '0')
+
+			return `${year}-${month}-${day}`
+		}
+	}
+
+	// 알림 목록 UI 업데이트
+	const renderNotificationList = (notifications) => {
+		let output = ''
+		notifications.forEach((notificationDto) => {
+			// 상대적인 시간으로 변환
+			const timeStamp = notificationDto.createdAt
+			const date = timeAgo(timeStamp)
+
+			// 읽음 여부 표시 클래스
+			let readClass = notificationDto.isRead == 'N'? 'unread' : ''
+
+			// type이 댓글인 경우 미리보기로 보여줄 내용
+			let commentSnippet = ''
+
+			// 알림 메시지
+			let notificationText = ''
+	
+			if(notificationDto.type == 'LIKE'){
+				notificationText = 
+				`
+					<strong>${notificationDto.senderId}</strong>님이 게시글을 좋아합니다.<br>
+				`
+			} else if(notificationDto.type == 'COMMENT'){
+				if(notificationDto.dataJson){
+					const parsedData = JSON.parse(notificationDto.dataJson)
+					if(parsedData.commentSnippet){
+						commentSnippet = parsedData.commentSnippet
+					}
+				}
+
+				notificationText = 
+				`
+					<strong>${notificationDto.senderId}</strong>님이 새로운 댓글을 달았습니다:
+					<span class="comment-preview-text">"${commentSnippet}"</span>
+				`
+			}
+
+			output += 
+			`	
+				<li class="notification-item ${readClass}">
+					<a href="${notificationDto.link}" data-notification-id="${notificationDto.notificationId}">
+						<div class="notification-content">
+							<span class="notification-main-text">${notificationText}</span>
+						</div>
+						<div class="notification-meta">
+							<span class="notification-time">${date}</span>
+							${readClass ? '<span class="new-badge">N</span>' : ''}
+						</div>
+					</a>
+				</li>
+			`
+		})
+		return output
+	}
+
+	// 안 읽은 메시지 총 개수 표시
+	const badge = document.querySelector("#notificationBadge")
+	const showUnreadCount = (unreadCount) => {
+		if(unreadCount > 0){
+			badge.style.display = 'block'
+			badge.textContent = unreadCount
+		} else {
+			badge.style.display = 'none'
+			badge.textContent = ''
+		}
+	}
+
+	// 알림 아이콘 표시
+	if(userId && notificationIcon && notificationModal){
+		// 로그인한 경우만 알림 아이콘 표시
+		notificationIcon.style.display = 'inline-block'
+		axios.get('/notification/getNotifications')
+			.then(response => {
+				// 최초 로드 시 읽지 않은 알림 개수만 가져오기
+				const unreadCount = response.data.unreadCount
+				showUnreadCount(unreadCount)
+			})
+
+			// 알림 데이터 가져오기
+		notificationIcon.addEventListener('click', (event) => {
+			event.stopPropagation()
+			notificationModal.classList.toggle('show')
+			
+			if(notificationModal.classList.contains('show')){
+				axios.get('/notification/getNotifications')
+					.then(response => {
+						const notifications = response.data.notificationDtos // List<>
+
+						// 초기화
+						const notificationListContainer  = notificationModal.querySelector(".notification-list") // <ul>
+						notificationListContainer.innerHTML = ''
+
+						// 알림이 없는 경우
+						if(notifications.length == 0){
+							notificationListContainer.innerHTML = '<li class="no-notifications">새로운 알림이 없습니다.</li>'
+							return
+						}
+
+						// 알림이 있는 경우
+						let output = renderNotificationList(notifications)
+						const infoMessage = 
+						`
+							<li class="notification-info-message">최근 3일 이내의 알림만 표시됩니다.</li>
+						`
+						output += infoMessage
+
+						notificationListContainer.innerHTML = output
+						notificationModal.querySelector(".notification-footer").style.display = 'block' // '모든 알림 보기' 표시
+						
+						// notificationListContainer.appendChild(infoMessage)
+						
+						// 클릭 시 읽음 처리 
+						const aElements = notificationModal.querySelectorAll("notification-item a")
+						aElements.forEach((a) => {
+							a.addEventListener('click', (event) => {
+								event.preventDefault()
+
+								const liElement = a.closest(".notification-item")
+								const notificationId = a.getAttribute("data-notification-id") // 알림 고유ID
+								if(liElement.classList.contains("unread")){
+									const data = {
+										notificationId: notificationId
+									}
+									
+									axios.patch('/notification/updateReadStatus', data)
+										.then(response => {
+											const updateResult = response.data.readStatusUpdated
+											const unreadCount = response.data.unreadCount
+											if(updateResult){
+												liElement.classList.remove('unread')
+												showUnreadCount(unreadCount)
+											}
+										})
+										.catch(error => {
+											console.error('error: ', error)
+										})
+								} 
+								window.location.href = a.getAttribute('href')
+							})
+						})
+				})
+			}
+		})
+
+		// 모달 닫기 버튼 클릭 시 닫기
+		const closeModalBtn = notificationModal.querySelector(".close-modal-btn")
+		if(closeModalBtn){
+			closeModalBtn.addEventListener('click', () => {
+				notificationModal.classList.remove('show')
+			})
+		}
+	} else {
+		notificationIcon.style.display = 'none'	
+	}
+
+})

--- a/src/main/webapp/resources/js/pagingList.js
+++ b/src/main/webapp/resources/js/pagingList.js
@@ -23,7 +23,11 @@ const userId = document.querySelector("#userId").getAttribute("data-userId")
 const userNickname = document.querySelector("#userNickname").getAttribute("data-userNickname")
 
 if(userId) {
-	document.querySelector("#welcomeText").innerHTML = `<a class="menubar-button-primary" href="/user/myPage">${userNickname}</a><span style="font-size: 16px;">님 환영합니다.<span>`
+	// 환영 메시지 표시
+	document.querySelector("#welcomeText").innerHTML = 
+	`
+		<a class="menubar-button-primary" href="/user/myPage">${userNickname}</a><span style="font-size: 16px;">님 환영합니다.<span>
+	`
 } else {
 	// 로그인 안 된 경우 기본 메시지(필요 시 활성화)
 	//document.querySelector("#welcomeText").innerHTML = "로그인"		

--- a/src/main/webapp/resources/js/socialJoinPage.js
+++ b/src/main/webapp/resources/js/socialJoinPage.js
@@ -82,7 +82,7 @@ nicknameInput.addEventListener('input', _.debounce(() => {
 
     // debounce: 입력이 멈춘 뒤 0.3초 후에 중복 검사 요청을 보내 서버 과부하 방지
     axios.get('/user/check-nickname-duplicate', {
-    params: {checkNickanme: nickname}
+    	params: {checkNickanme: nickname}
     })
         .then(response => {
             if(response.data){


### PR DESCRIPTION
## 📌 변경 사항
- 알림 기능 전반 구현 (좋아요/댓글 알림 처리)
- 알림 아이콘 클릭 시 최근 3일 내 알림 표시 (읽음 여부 관계없음)
- 알림 메시지 클릭 시 관련 게시글 또는 댓글 위치로 이동
- 모든 알림 보기 페이지(`/notification/getNotifications.jsp`) 구현 및 무한 스크롤 적용
- 알림 읽음 처리 및 읽지 않은 알림 배지 수 실시간 업데이트
- 알림 클릭 여부에 따라 게시글 상세 페이지 내 댓글 링크 동작 방식 분기
- db 테이블 생성 후 `is_read` 컬럼 타입을 `char` → `String`으로 변경

## 🛠️ 수정한 이유
- 사용자 상호작용(좋아요/댓글 등)에 따른 실시간 알림 제공으로 사용자 경험 개선
- 알림 클릭 시 해당 컨텍스트로 자연스럽게 연결될 수 있도록 이동 경로 개선
- 댓글 위치가 변할 수 있는 이슈를 고려해 댓글 ID 기준으로 페이지 재계산 처리
- 무한 스크롤 구현 시 옵저버 종료 조건 처리 및 UX 향상을 위해 메시지 추가
- 알림을 클릭할 때마다 읽음 상태 및 알림 뱃지 수 동기화 처리
- 알림 데이터 `JSP` 렌더링 시 타입 오류 방지를 위해 `is_read` 타입 변경

## 🔍 주요 변경 파일
- BoardController.java
- NotificationController.java
- BoardDao.java
- BoardService.java
- LikeService.java
- NotificationDao.java
- NotificationDto.java
- NotificationResponseDto.java
- NotificationService.java
- Boardmapper.xml
- Notificationmapper.xml
- loginInfo.jsp
- getNotifications.jsp
- detailPage.jsp
- common.css
- getNotifications.css
- detailPage.css
- loginInfo.js
- getNotifications.js
- detailPage.js



## ✅ 테스트 내용
- [x] 알림 모달 정상 표시 확인 (최근 3일)
- [x] 모든 알림 보기 페이지 무한 스크롤 동작 확인
- [x] 알림 클릭 시 읽음 처리 및 배지 숫자 실시간 감소 확인
- [x] 댓글 알림 클릭 시 해당 댓글로 스크롤 및 하이라이트 정상 동작 확인
- [x] 비알림 경로를 통한 상세보기 진입 시 링크 변경 없는 것 확인

## 🔗 관련 이슈
closes #79 
